### PR TITLE
Peer Set Method Error Return and Close/Shutdown for Peer Connections

### DIFF
--- a/galaxycache.go
+++ b/galaxycache.go
@@ -311,7 +311,7 @@ func (g *Galaxy) load(ctx context.Context, key string, dest Sink) (value ByteVie
 			g.Stats.PeerErrors.Add(1)
 			stats.Record(ctx, MPeerErrors.M(1))
 			// TODO(bradfitz): log the peer's error? keep
-			// log of the past few for /galaxycachez?  It's
+			// log of the past few for /galaxycache?  It's
 			// probably boring (normal task movement), so not
 			// worth logging I imagine.
 		}

--- a/galaxycache.go
+++ b/galaxycache.go
@@ -129,8 +129,12 @@ func (universe *Universe) GetGalaxy(name string) *Galaxy {
 // Set updates the Universe's list of peers (contained in the PeerPicker).
 // Each PeerURL value should be a valid base URL,
 // for example "http://example.net:8000".
-func (universe *Universe) Set(peerURLs ...string) {
-	universe.peerPicker.set(peerURLs...)
+func (universe *Universe) Set(peerURLs ...string) error {
+	return universe.peerPicker.set(peerURLs...)
+}
+
+func (universe *Universe) Shutdown() error {
+	return universe.peerPicker.shutdown()
 }
 
 // A Galaxy is a cache namespace and associated data spread over

--- a/galaxycache_test.go
+++ b/galaxycache_test.go
@@ -233,6 +233,11 @@ type TestFetcher struct {
 	hits int
 	fail bool
 }
+
+func (fetcher *TestFetcher) Close() error {
+	return nil
+}
+
 type testFetchers []RemoteFetcher
 
 func (fetcher *TestFetcher) Fetch(ctx context.Context, in *pb.GetRequest, out *pb.GetResponse) error {
@@ -244,13 +249,13 @@ func (fetcher *TestFetcher) Fetch(ctx context.Context, in *pb.GetRequest, out *p
 	return nil
 }
 
-func (proto *TestProtocol) NewFetcher(url string) RemoteFetcher {
+func (proto *TestProtocol) NewFetcher(url string) (RemoteFetcher, error) {
 	newTestFetcher := &TestFetcher{
 		hits: 0,
 		fail: false,
 	}
 	proto.TestFetchers[url] = newTestFetcher
-	return newTestFetcher
+	return newTestFetcher, nil
 }
 
 // TestPeers tests to ensure that an instance with given hash

--- a/http.go
+++ b/http.go
@@ -72,10 +72,9 @@ func NewHTTPFetchProtocol(opts *HTTPOptions) *HTTPFetchProtocol {
 	return newProto
 }
 
-// NewFetcher implements the Protocol interface for HTTPProtocol by
-// constructing a new fetcher to fetch from peers via HTTP
-func (hp *HTTPFetchProtocol) NewFetcher(url string) RemoteFetcher {
-	return &httpFetcher{transport: hp.transport, baseURL: url + hp.basePath}
+// NewFetcher implements the Protocol interface for HTTPProtocol by constructing a new fetcher to fetch from peers via HTTP
+func (hp *HTTPFetchProtocol) NewFetcher(url string) (RemoteFetcher, error) {
+	return &httpFetcher{transport: hp.transport, baseURL: url + hp.basePath}, nil
 }
 
 // HTTPHandler implements the HTTP handler necessary to serve an HTTP
@@ -155,6 +154,7 @@ var bufferPool = sync.Pool{
 	New: func() interface{} { return new(bytes.Buffer) },
 }
 
+// Fetch here implements the RemoteFetcher interface for sending a GET request over HTTP to a peer
 func (h *httpFetcher) Fetch(ctx context.Context, in *pb.GetRequest, out *pb.GetResponse) error {
 	u := fmt.Sprintf(
 		"%v%v/%v",
@@ -189,5 +189,10 @@ func (h *httpFetcher) Fetch(ctx context.Context, in *pb.GetRequest, out *pb.GetR
 	if err != nil {
 		return fmt.Errorf("decoding response body: %v", err)
 	}
+	return nil
+}
+
+// Close here implements the RemoteFetcher interface for closing (does nothing for HTTP)
+func (h *httpFetcher) Close() error {
 	return nil
 }

--- a/http.go
+++ b/http.go
@@ -72,7 +72,8 @@ func NewHTTPFetchProtocol(opts *HTTPOptions) *HTTPFetchProtocol {
 	return newProto
 }
 
-// NewFetcher implements the Protocol interface for HTTPProtocol by constructing a new fetcher to fetch from peers via HTTP
+// NewFetcher implements the Protocol interface for HTTPProtocol by constructing
+// a new fetcher to fetch from peers via HTTP
 func (hp *HTTPFetchProtocol) NewFetcher(url string) (RemoteFetcher, error) {
 	return &httpFetcher{transport: hp.transport, baseURL: url + hp.basePath}, nil
 }

--- a/http_test.go
+++ b/http_test.go
@@ -66,7 +66,7 @@ func TestHTTPHandler(t *testing.T) {
 	defer cancel()
 
 	for _, listener := range peerListeners {
-		go makeServerUniverse(ctx, t, peerAddresses, listener)
+		go makeHTTPServerUniverse(ctx, t, peerAddresses, listener)
 	}
 
 	for _, key := range testKeys(nGets) {
@@ -82,7 +82,7 @@ func TestHTTPHandler(t *testing.T) {
 
 }
 
-func makeServerUniverse(ctx context.Context, t testing.TB, addresses []string, listener net.Listener) {
+func makeHTTPServerUniverse(ctx context.Context, t testing.TB, addresses []string, listener net.Listener) {
 	universe := NewUniverse(NewHTTPFetchProtocol(nil), "http://"+listener.Addr().String())
 	serveMux := http.NewServeMux()
 	wrappedHandler := &ochttp.Handler{Handler: serveMux}

--- a/http_test.go
+++ b/http_test.go
@@ -55,7 +55,10 @@ func TestHTTPHandler(t *testing.T) {
 	universe := NewUniverse(NewHTTPFetchProtocol(nil), "shouldBeIgnored")
 	serveMux := http.NewServeMux()
 	RegisterHTTPHandler(universe, nil, serveMux)
-	universe.Set(addrToURL(peerAddresses)...)
+	err := universe.Set(addrToURL(peerAddresses)...)
+	if err != nil {
+		t.Errorf("Error setting peers: %s", err)
+	}
 
 	getter := GetterFunc(func(ctx context.Context, key string, dest Sink) error {
 		return fmt.Errorf("oh no! Local get occurred")
@@ -87,8 +90,10 @@ func makeHTTPServerUniverse(ctx context.Context, t testing.TB, addresses []strin
 	serveMux := http.NewServeMux()
 	wrappedHandler := &ochttp.Handler{Handler: serveMux}
 	RegisterHTTPHandler(universe, nil, serveMux)
-	universe.Set(addrToURL(addresses)...)
-
+	err := universe.Set(addrToURL(addresses)...)
+	if err != nil {
+		t.Errorf("Error setting peers: %s", err)
+	}
 	getter := GetterFunc(func(ctx context.Context, key string, dest Sink) error {
 		dest.SetString(":" + key)
 		return nil

--- a/peers.go
+++ b/peers.go
@@ -112,6 +112,7 @@ func (pp *PeerPicker) set(peerURLs ...string) error {
 		if _, ok := pp.fetchers[url]; !ok {
 			pp.fetchers[url], err = pp.fetchingProtocol.NewFetcher(url)
 			if err != nil {
+				delete(pp.fetchers, url)
 				return err
 			}
 		}

--- a/peers.go
+++ b/peers.go
@@ -107,7 +107,6 @@ func (pp *PeerPicker) set(peerURLs ...string) error {
 	}
 
 	for _, url := range peerURLs {
-		// fmt.Printf("[%s]: connecting to [%s]\n", pp.selfURL, url) // TODO: remove print
 		var err error
 		pp.fetchers[url], err = pp.fetchingProtocol.NewFetcher(url)
 		if err != nil {
@@ -144,6 +143,8 @@ func (pp *PeerPicker) shutdown() error {
 // HTTP or GRPC) and implements the instantiation method for that
 // connection (creating a new RemoteFetcher)
 type FetchProtocol interface {
-	// NewFetcher instantiates the connection between the current and a remote peer and returns a RemoteFetcher to be used for fetching data from that peer
+	// NewFetcher instantiates the connection between the current and a
+	// remote peer and returns a RemoteFetcher to be used for fetching
+	// data from that peer
 	NewFetcher(url string) (RemoteFetcher, error)
 }

--- a/peers.go
+++ b/peers.go
@@ -108,19 +108,22 @@ func (pp *PeerPicker) set(peerURLs ...string) error {
 
 	for _, url := range peerURLs {
 		var err error
-		pp.fetchers[url], err = pp.fetchingProtocol.NewFetcher(url)
-		if err != nil {
-			return err
+		// open a new fetcher if there is currently no peer at url
+		if _, ok := pp.fetchers[url]; !ok {
+			pp.fetchers[url], err = pp.fetchingProtocol.NewFetcher(url)
+			if err != nil {
+				return err
+			}
 		}
 		delete(currFetchers, url)
 	}
 
 	for url := range currFetchers {
 		err := pp.fetchers[url].Close()
+		delete(pp.fetchers, url)
 		if err != nil {
 			return err
 		}
-		delete(pp.fetchers, url)
 	}
 	return nil
 }

--- a/peers.go
+++ b/peers.go
@@ -107,14 +107,13 @@ func (pp *PeerPicker) set(peerURLs ...string) error {
 	}
 
 	for _, url := range peerURLs {
-		var err error
 		// open a new fetcher if there is currently no peer at url
 		if _, ok := pp.fetchers[url]; !ok {
-			pp.fetchers[url], err = pp.fetchingProtocol.NewFetcher(url)
+			newFetcher, err := pp.fetchingProtocol.NewFetcher(url)
 			if err != nil {
-				delete(pp.fetchers, url)
 				return err
 			}
+			pp.fetchers[url] = newFetcher
 		}
 		delete(currFetchers, url)
 	}

--- a/peers.go
+++ b/peers.go
@@ -25,6 +25,7 @@ package galaxycache
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/vimeo/groupcache/consistenthash"
@@ -38,6 +39,8 @@ const defaultReplicas = 50
 // to each other peer address
 type RemoteFetcher interface {
 	Fetch(context context.Context, in *pb.GetRequest, out *pb.GetResponse) error
+	// Close closes a client-side connection (for GRPC use only)
+	Close() error
 }
 
 // PeerPicker is in charge of dealing with peers: it contains the hashing
@@ -92,23 +95,55 @@ func (pp *PeerPicker) pickPeer(key string) (RemoteFetcher, bool) {
 	return nil, false
 }
 
-func (pp *PeerPicker) set(peerURLs ...string) {
+func (pp *PeerPicker) set(peerURLs ...string) error {
 	pp.mu.Lock()
 	defer pp.mu.Unlock()
 	pp.peers = consistenthash.New(pp.opts.Replicas, pp.opts.HashFn)
 	pp.peers.Add(peerURLs...)
-	pp.fetchers = make(map[string]RemoteFetcher, len(peerURLs))
-	for _, URL := range peerURLs {
-		pp.fetchers[URL] = pp.fetchingProtocol.NewFetcher(URL)
+	currFetchers := make(map[string]struct{})
+
+	for url := range pp.fetchers {
+		currFetchers[url] = struct{}{}
 	}
+
+	for _, url := range peerURLs {
+		// fmt.Printf("[%s]: connecting to [%s]\n", pp.selfURL, url) // TODO: remove print
+		var err error
+		pp.fetchers[url], err = pp.fetchingProtocol.NewFetcher(url)
+		if err != nil {
+			return err
+		}
+		delete(currFetchers, url)
+	}
+
+	for url := range currFetchers {
+		err := pp.fetchers[url].Close()
+		if err != nil {
+			return err
+		}
+		delete(pp.fetchers, url)
+	}
+	return nil
+}
+
+func (pp *PeerPicker) shutdown() error {
+	errs := []error{}
+	for _, fetcher := range pp.fetchers {
+		err := fetcher.Close()
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("Failed to close: %v", errs)
+	}
+	return nil
 }
 
 // FetchProtocol defines the chosen fetching protocol to peers (namely
 // HTTP or GRPC) and implements the instantiation method for that
 // connection (creating a new RemoteFetcher)
 type FetchProtocol interface {
-	// NewFetcher instantiates the connection between the current and
-	// a remote peer and returns a RemoteFetcher to be used for fetching
-	// data from that peer
-	NewFetcher(url string) RemoteFetcher
+	// NewFetcher instantiates the connection between the current and a remote peer and returns a RemoteFetcher to be used for fetching data from that peer
+	NewFetcher(url string) (RemoteFetcher, error)
 }

--- a/peers.go
+++ b/peers.go
@@ -39,7 +39,7 @@ const defaultReplicas = 50
 // to each other peer address
 type RemoteFetcher interface {
 	Fetch(context context.Context, in *pb.GetRequest, out *pb.GetResponse) error
-	// Close closes a client-side connection (for GRPC use only)
+	// Close closes a client-side connection (may be a nop)
 	Close() error
 }
 


### PR DESCRIPTION
Add an error return to the peer Set method in case of failure (primarily for the gRPC implementation, since setting opens the connection immediately and could fail). Also adds Close/Shutdown methods for ending those connections, again primarily for the upcoming gRPC.